### PR TITLE
Run CI for push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - ci_run_push_to_main
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - ci_run_push_to_main
 
 permissions:
   contents: write


### PR DESCRIPTION
After the last changes, the CI only run on a pull request which was intended. However, the pipeline did not run when merging into main. But it has to run on main, because only on main the gh-pages are created. So now, the pipeline additionally runs for pushing to main.