### PR TITLE
Add scientific colormaps 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.1.0 (2024-11-06)
+------------------
+
+* Use Scientific colour maps from Crameri.
+
 1.0.0 (2024-08-12) Strawberry Pie
 ---------------------------------
 

--- a/sarvey/objects.py
+++ b/sarvey/objects.py
@@ -38,6 +38,7 @@ from pyproj import Proj, CRS
 from pyproj.aoi import AreaOfInterest
 from pyproj.database import query_utm_crs_info
 from logging import Logger
+from cmcrameri import cm
 
 from miaplpy.objects.slcStack import slcStack
 from mintpy.utils import readfile
@@ -130,7 +131,7 @@ class AmplitudeImage:
         if ax is None:
             fig = plt.figure(figsize=(15, 5))
             ax = fig.add_subplot()
-        ax.imshow(self.background_map, cmap=plt.cm.get_cmap("gray"))
+        ax.imshow(self.background_map, cmap=cm.grayC)
         meta = {"ORBIT_DIRECTION": self.orbit_direction}
         auto_flip_direction(meta, ax=ax, print_msg=False)
 

--- a/sarvey/preparation.py
+++ b/sarvey/preparation.py
@@ -198,7 +198,7 @@ def selectPixels(*, path: str, selection_method: str, thrsh: float,
         cand_mask = quality >= thrsh
         grid_min_val = False
         unit = "Temporal\nCoherence [ ]"
-        cmap = "autumn"
+        cmap = "lajolla"
 
     if selection_method == "miaplpy":
         raise NotImplementedError("This part is not developed yet. MiaplPy data is read in another way.")
@@ -208,7 +208,7 @@ def selectPixels(*, path: str, selection_method: str, thrsh: float,
         # quality = pl_coherence
         # grid_min_val = False
         # unit = "Phase-Linking\nCoherence [ ]"
-        # cmap = "autumn"
+        # cmap = "lajolla"
 
     if grid_size is not None:  # -> sparse pixel selection
         coord_utm_obj = CoordinatesUTM(file_path=join(path, "coordinates_utm.h5"), logger=logger)

--- a/sarvey/processing.py
+++ b/sarvey/processing.py
@@ -30,9 +30,9 @@
 """Processing module for SARvey."""
 from os.path import join, exists
 import matplotlib.pyplot as plt
-from matplotlib import colormaps
 import numpy as np
 from logging import Logger
+import cmcrameri as cmc
 
 from miaplpy.objects.slcStack import slcStack
 from mintpy.utils import readfile
@@ -207,7 +207,7 @@ class Processing:
 
         fig = plt.figure(figsize=(15, 5))
         ax = fig.add_subplot()
-        im = ax.imshow(temp_coh, cmap=colormaps["gray"], vmin=0, vmax=1)
+        im = ax.imshow(temp_coh, cmap=cmc.cm.cmaps["grayC"], vmin=0, vmax=1)
         auto_flip_direction(slc_stack_obj.metadata, ax=ax, print_msg=True)
         ax.set_xlabel("Range")
         ax.set_ylabel("Azimuth")
@@ -243,11 +243,11 @@ class Processing:
 
         fig = plt.figure(figsize=(15, 5))
         ax = fig.add_subplot()
-        ax.imshow(mask_valid_area, cmap=plt.cm.get_cmap("gray"), alpha=0.5, zorder=10, vmin=0, vmax=1)
+        ax.imshow(mask_valid_area, cmap=cmc.cm.cmaps["grayC"], alpha=0.5, zorder=10, vmin=0, vmax=1)
         bmap_obj.plot(ax=ax, logger=self.logger)
         coord_xy = np.array(np.where(cand_mask1)).transpose()
         val = np.ones_like(cand_mask1)
-        sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=val[cand_mask1], s=0.5, cmap=plt.get_cmap("autumn_r"),
+        sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=val[cand_mask1], s=0.5, cmap=cmc.cm.cmaps["lajolla_r"],
                         vmin=1, vmax=2)  # set min, max to ensure that points are yellow
         cbar = plt.colorbar(sc, pad=0.03, shrink=0.5)
         cbar.ax.set_visible(False)  # make size of axis consistent with all others
@@ -322,7 +322,7 @@ class Processing:
             ax, cbar = viewer.plotColoredPointNetwork(x=point_obj.coord_xy[:, 1], y=point_obj.coord_xy[:, 0],
                                                       arcs=net_par_obj.arcs[arc_mask, :],
                                                       val=net_par_obj.gamma[arc_mask],
-                                                      ax=ax, linewidth=1, cmap_name="autumn", clim=(0, 1))
+                                                      ax=ax, linewidth=1, cmap="lajolla", clim=(0, 1))
             ax.set_title("Coherence from temporal unwrapping\n"
                          r"(only arcs with $\gamma \leq$ {} "
                          "shown)\nBefore outlier removal".format(thrsh_visualisation))
@@ -347,7 +347,7 @@ class Processing:
             ax, cbar = viewer.plotColoredPointNetwork(x=coord_xy[:, 1], y=coord_xy[:, 0],
                                                       arcs=net_par_obj.arcs[arc_mask, :],
                                                       val=net_par_obj.gamma[arc_mask],
-                                                      ax=ax, linewidth=1, cmap_name="autumn", clim=(0, 1))
+                                                      ax=ax, linewidth=1, cmap="lajolla", clim=(0, 1))
             ax.set_title("Coherence from temporal unwrapping\n"
                          r"(only arcs with $\gamma \leq$ {} "
                          "shown)\nAfter outlier removal".format(thrsh_visualisation))
@@ -403,7 +403,8 @@ class Processing:
         #                                               max_rm_fraction=0.001)
         fig = viewer.plotScatter(value=-demerr, coord=point_obj.coord_xy,
                                  ttl="Parameter integration: DEM correction in [m]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="jet_r", symmetric=True, logger=self.logger)[0]
+                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+                                 logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_2_estimation_dem_correction.png"), dpi=300)
         plt.close(fig)
 
@@ -422,7 +423,8 @@ class Processing:
         #                                            max_rm_fraction=0.001)
         fig = viewer.plotScatter(value=-vel, coord=point_obj.coord_xy,
                                  ttl="Parameter integration: mean velocity in [m / year]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="jet_r", symmetric=True, logger=self.logger)[0]
+                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+                                 logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_2_estimation_velocity.png"), dpi=300)
         plt.close(fig)
 
@@ -509,7 +511,7 @@ class Processing:
                                                   y=point_obj.coord_xy[:, 0],
                                                   arcs=arcs,
                                                   val=np.zeros(arcs.shape[0], dtype=np.float32),
-                                                  ax=ax, linewidth=0.5, cmap_name="hot", clim=(0, 1))
+                                                  ax=ax, linewidth=0.5, cmap="lajolla", clim=(0, 1))
         cbar.ax.set_visible(False)
         ax.set_xlabel("Range")
         ax.set_ylabel("Azimuth")
@@ -584,7 +586,7 @@ class Processing:
         auto_corr_img[~mask] = np.inf
 
         fig = viewer.plotScatter(value=auto_corr, coord=point1_obj.coord_xy, bmap_obj=bmap_obj,
-                                 ttl="Temporal autocorrelation", unit="[ ]", s=3.5, cmap="autumn_r",
+                                 ttl="Temporal autocorrelation", unit="[ ]", s=3.5, cmap="lajolla_r",
                                  vmin=0, vmax=1, logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_3_temporal_autocorrelation.png"), dpi=300)
         plt.close(fig)
@@ -618,7 +620,7 @@ class Processing:
         # store plot for quality control during processing
         fig, ax = viewer.plotScatter(value=auto_corr_img[cand_mask_sparse], coord=point1_obj.coord_xy,
                                      bmap_obj=bmap_obj, ttl="Selected pixels for APS estimation",
-                                     unit="Auto-correlation\n[ ]", s=5, cmap="autumn_r", vmin=0, vmax=1,
+                                     unit="Auto-correlation\n[ ]", s=5, cmap="lajolla_r", vmin=0, vmax=1,
                                      logger=self.logger)[:2]
         viewer.plotGridFromBoxList(box_list=box_list, ax=ax, edgecolor="k", linewidth=0.2)
         fig.savefig(join(self.path, "pic", "step_3_stable_points.png"), dpi=300)
@@ -669,12 +671,12 @@ class Processing:
 
                 fig = plt.figure(figsize=(15, 5))
                 ax = fig.add_subplot()
-                ax.imshow(mask_pl_aoi, cmap=plt.cm.get_cmap("gray"), alpha=0.5, zorder=10, vmin=0, vmax=1)
+                ax.imshow(mask_pl_aoi, cmap=cmc.cm.cmaps["grayC"], alpha=0.5, zorder=10, vmin=0, vmax=1)
                 bmap_obj.plot(ax=ax, logger=self.logger)
                 coord_xy = np.array(np.where(cand_mask_pl)).transpose()
                 val = np.ones_like(cand_mask_pl)
                 sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=val[cand_mask_pl], s=0.5,
-                                cmap=plt.get_cmap("autumn_r"),
+                                cmap=cmc.cm.cmaps["lajolla_r"],
                                 vmin=1, vmax=2)  # set min, max to ensure that points are yellow
                 cbar = plt.colorbar(sc, pad=0.03, shrink=0.5)
                 cbar.ax.set_visible(False)  # make size of axis consistent with all others
@@ -707,12 +709,12 @@ class Processing:
 
         fig = plt.figure(figsize=(15, 5))
         ax = fig.add_subplot()
-        ax.imshow(mask_valid_area, cmap=plt.cm.get_cmap("gray"), alpha=0.5, zorder=10, vmin=0, vmax=1)
+        ax.imshow(mask_valid_area, cmap=cmc.cm.cmaps["grayC"], alpha=0.5, zorder=10, vmin=0, vmax=1)
         bmap_obj.plot(ax=ax, logger=self.logger)
         coord_xy = np.array(np.where(cand_mask2)).transpose()
         val = np.ones_like(cand_mask2)
-        sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=val[cand_mask2], s=0.5, cmap=plt.get_cmap("autumn_r"),
-                        vmin=1, vmax=2)  # set min, max to ensure that points are yellow
+        sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=val[cand_mask2], s=0.5, cmap=cmc.cm.cmaps["lajolla_r"],
+                        vmin=0, vmax=10)  # set min, max to ensure that points are yellow
         cbar = plt.colorbar(sc, pad=0.03, shrink=0.5)
         cbar.ax.set_visible(False)  # make size of axis consistent with all others
         plt.tight_layout()
@@ -951,8 +953,8 @@ class Processing:
 
         bmap_obj = AmplitudeImage(file_path=join(self.path, "background_map.h5"))
         fig = viewer.plotScatter(value=gamma, coord=point2_obj.coord_xy, bmap_obj=bmap_obj,
-                                 ttl="Coherence from temporal unwrapping\nBefore outlier removal", s=3.5, cmap="autumn",
-                                 vmin=0, vmax=1, logger=self.logger)[0]
+                                 ttl="Coherence from temporal unwrapping\nBefore outlier removal", s=3.5,
+                                 cmap="lajolla", vmin=0, vmax=1, logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_4_temporal_unwrapping_p2_coh{}.png".format(coh_value)), dpi=300)
         plt.close(fig)
 
@@ -976,20 +978,22 @@ class Processing:
         plt.close(fig)
 
         fig = viewer.plotScatter(value=gamma[mask_gamma], coord=point2_obj.coord_xy, bmap_obj=bmap_obj,
-                                 ttl="Coherence from temporal unwrapping\nAfter outlier removal", s=3.5, cmap="autumn",
-                                 vmin=0, vmax=1, logger=self.logger)[0]
+                                 ttl="Coherence from temporal unwrapping\nAfter outlier removal", s=3.5,
+                                 cmap="lajolla", vmin=0, vmax=1, logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_4_temporal_unwrapping_p2_coh{}_reduced.png".format(coh_value)),
                     dpi=300)
         plt.close(fig)
 
         fig = viewer.plotScatter(value=-vel[mask_gamma], coord=point2_obj.coord_xy,
                                  ttl="Mean velocity in [m / year]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="jet_r", symmetric=True, logger=self.logger)[0]
+                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+                                 logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_4_estimation_velocity_p2_coh{}.png".format(coh_value)), dpi=300)
         plt.close(fig)
 
         fig = viewer.plotScatter(value=-demerr[mask_gamma], coord=point2_obj.coord_xy, ttl="DEM error in [m]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="jet_r", symmetric=True, logger=self.logger)[0]
+                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+                                 logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_4_estimation_dem_correction_p2_coh{}.png".format(coh_value)), dpi=300)
         plt.close(fig)
 

--- a/sarvey/processing.py
+++ b/sarvey/processing.py
@@ -403,7 +403,7 @@ class Processing:
         #                                               max_rm_fraction=0.001)
         fig = viewer.plotScatter(value=-demerr, coord=point_obj.coord_xy,
                                  ttl="Parameter integration: DEM correction in [m]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+                                 bmap_obj=bmap_obj, s=3.5, cmap="vanimo", symmetric=True,
                                  logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_2_estimation_dem_correction.png"), dpi=300)
         plt.close(fig)
@@ -586,7 +586,7 @@ class Processing:
         auto_corr_img[~mask] = np.inf
 
         fig = viewer.plotScatter(value=auto_corr, coord=point1_obj.coord_xy, bmap_obj=bmap_obj,
-                                 ttl="Temporal autocorrelation", unit="[ ]", s=3.5, cmap="lajolla_r",
+                                 ttl="Temporal autocorrelation", unit="[ ]", s=3.5, cmap="lajolla",
                                  vmin=0, vmax=1, logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_3_temporal_autocorrelation.png"), dpi=300)
         plt.close(fig)
@@ -620,7 +620,7 @@ class Processing:
         # store plot for quality control during processing
         fig, ax = viewer.plotScatter(value=auto_corr_img[cand_mask_sparse], coord=point1_obj.coord_xy,
                                      bmap_obj=bmap_obj, ttl="Selected pixels for APS estimation",
-                                     unit="Auto-correlation\n[ ]", s=5, cmap="lajolla_r", vmin=0, vmax=1,
+                                     unit="Auto-correlation\n[ ]", s=5, cmap="lajolla", vmin=0, vmax=1,
                                      logger=self.logger)[:2]
         viewer.plotGridFromBoxList(box_list=box_list, ax=ax, edgecolor="k", linewidth=0.2)
         fig.savefig(join(self.path, "pic", "step_3_stable_points.png"), dpi=300)
@@ -991,8 +991,8 @@ class Processing:
         fig.savefig(join(self.path, "pic", "step_4_estimation_velocity_p2_coh{}.png".format(coh_value)), dpi=300)
         plt.close(fig)
 
-        fig = viewer.plotScatter(value=-demerr[mask_gamma], coord=point2_obj.coord_xy, ttl="DEM error in [m]",
-                                 bmap_obj=bmap_obj, s=3.5, cmap="roma", symmetric=True,
+        fig = viewer.plotScatter(value=-demerr[mask_gamma], coord=point2_obj.coord_xy, ttl="DEM correction in [m]",
+                                 bmap_obj=bmap_obj, s=3.5, cmap="vanimo", symmetric=True,
                                  logger=self.logger)[0]
         fig.savefig(join(self.path, "pic", "step_4_estimation_dem_correction_p2_coh{}.png".format(coh_value)), dpi=300)
         plt.close(fig)

--- a/sarvey/sarvey_plot.py
+++ b/sarvey/sarvey_plot.py
@@ -41,7 +41,6 @@ import sys
 import cmcrameri as cmc
 
 from mintpy.utils import ptime
-from mintpy.objects.colors import ColormapExt
 from mintpy.utils.plot import auto_flip_direction
 
 from sarvey.ifg_network import IfgNetwork
@@ -98,27 +97,13 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=demerr, s=scatter_size,
-                    cmap=cmc.cm.cmaps["roma"])
+                    cmap=cmc.cm.cmaps["vanimo"])
     plt.colorbar(sc, label="[m]", pad=0.03, shrink=0.5)
     plt.title("DEM correction")
     plt.ylabel('Azimuth')
     plt.xlabel('Range')
     plt.tight_layout()
     plt.gcf().savefig(join(save_path, "map_dem_correction.png"), dpi=300)
-    if interactive:
-        plt.show()
-    else:
-        plt.close(plt.gcf())
-
-    ax = bmap_obj.plot(logger=logger)
-    sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=omega, s=scatter_size,
-                    cmap=cmc.cm.cmaps["lajolla_r"], vmin=0, vmax=np.quantile(omega, 0.95))
-    plt.colorbar(sc, label="", pad=0.03, shrink=0.5)
-    plt.title("Squared sum of residuals")
-    plt.ylabel('Azimuth')
-    plt.xlabel('Range')
-    plt.tight_layout()
-    plt.gcf().savefig(join(save_path, "map_squared_sum_of_residuals.png"), dpi=300)
     if interactive:
         plt.show()
     else:
@@ -161,7 +146,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=stc * 100, s=scatter_size,
-                    cmap=cmc.cm.cmaps["lajolla_r"])
+                    cmap=cmc.cm.cmaps["lajolla"])
     plt.colorbar(sc, label="[cm]", pad=0.03, shrink=0.5)
     plt.title("Spatiotemporal consistency")
     plt.ylabel('Azimuth')
@@ -319,11 +304,11 @@ def plotAllIfgs(*, obj_name: str, save_path: str, interactive: bool = False, log
     start_time = time.time()
     logger.info(msg="plot and save figures of ifgs.")
     for i in range(num_ifgs):
-        fig = plt.figure(figsize=[15, 5])
+        fig = plt.figure(figsize=(15, 5))
         ax = fig.add_subplot()
         ifg = np.angle(ifgs[:, :, i])
         ifg[ifg == 0] = np.nan
-        im = plt.imshow(ifg, cmap=ColormapExt('cmy').colormap, interpolation='nearest', vmin=-np.pi, vmax=np.pi)
+        im = plt.imshow(ifg, cmap=cmc.cm.cmaps["romaO"], interpolation='nearest', vmin=-np.pi, vmax=np.pi)
         auto_flip_direction(ifg_stack_obj.metadata, ax=ax, print_msg=False)
         ax.set_xlabel("Range")
         ax.set_ylabel("Azimuth")

--- a/sarvey/sarvey_plot.py
+++ b/sarvey/sarvey_plot.py
@@ -38,7 +38,7 @@ import numpy as np
 import logging
 from logging import Logger
 import sys
-from cmcrameri import cm as cmc
+import cmcrameri as cmc
 
 from mintpy.utils import ptime
 from mintpy.objects.colors import ColormapExt
@@ -98,7 +98,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=demerr, s=scatter_size,
-                    cmap=cmc.roma)
+                    cmap=cmc.cm.cmaps["roma"])
     plt.colorbar(sc, label="[m]", pad=0.03, shrink=0.5)
     plt.title("DEM correction")
     plt.ylabel('Azimuth')
@@ -112,7 +112,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=omega, s=scatter_size,
-                    cmap=cmc.lajolla_r, vmin=0, vmax=np.quantile(omega, 0.95))
+                    cmap=cmc.cm.cmaps["lajolla_r"], vmin=0, vmax=np.quantile(omega, 0.95))
     plt.colorbar(sc, label="", pad=0.03, shrink=0.5)
     plt.title("Squared sum of residuals")
     plt.ylabel('Azimuth')
@@ -128,7 +128,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=vel * 100, s=scatter_size,
-                    cmap=cmc.roma,
+                    cmap=cmc.cm.cmaps["roma"],
                     vmin=-v_range, vmax=v_range)
     plt.colorbar(sc, label="[cm / year]", pad=0.03, shrink=0.5)
     plt.title("Mean Velocity")
@@ -143,7 +143,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=coherence, vmin=0, vmax=1, s=scatter_size,
-                    cmap=cmc.lajolla)
+                    cmap=cmc.cm.cmaps["lajolla"])
     plt.colorbar(sc, label="[-]", pad=0.03, shrink=0.5)
     plt.title("Temporal coherence")
     plt.ylabel('Azimuth')
@@ -161,7 +161,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=stc * 100, s=scatter_size,
-                    cmap=cmc.lajolla_r)
+                    cmap=cmc.cm.cmaps["lajolla_r"])
     plt.colorbar(sc, label="[cm]", pad=0.03, shrink=0.5)
     plt.title("Spatiotemporal consistency")
     plt.ylabel('Azimuth')

--- a/sarvey/sarvey_plot.py
+++ b/sarvey/sarvey_plot.py
@@ -441,7 +441,7 @@ def main(iargs=None):
 
     config = loadConfiguration(path=config_file_path)
 
-    folder_name = "p1" if "p1" in basename(args.input_file) else basename(args.input_file)[:5]
+    folder_name = "p1" if "p1" in basename(args.input_file) else basename(args.input_file)[:8]
     folder_name = "ifgs" if "ifg_stack" in basename(args.input_file) else folder_name
 
     save_path = join(dirname(args.input_file), "pic", folder_name)

--- a/sarvey/sarvey_plot.py
+++ b/sarvey/sarvey_plot.py
@@ -34,11 +34,11 @@ import os
 from os.path import join, basename, dirname
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib import colormaps
 import numpy as np
 import logging
 from logging import Logger
 import sys
+from cmcrameri import cm as cmc
 
 from mintpy.utils import ptime
 from mintpy.objects.colors import ColormapExt
@@ -98,7 +98,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=demerr, s=scatter_size,
-                    cmap=colormaps["jet_r"])
+                    cmap=cmc.roma)
     plt.colorbar(sc, label="[m]", pad=0.03, shrink=0.5)
     plt.title("DEM correction")
     plt.ylabel('Azimuth')
@@ -112,7 +112,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=omega, s=scatter_size,
-                    cmap=colormaps["autumn_r"])
+                    cmap=cmc.lajolla_r, vmin=0, vmax=np.quantile(omega, 0.95))
     plt.colorbar(sc, label="", pad=0.03, shrink=0.5)
     plt.title("Squared sum of residuals")
     plt.ylabel('Azimuth')
@@ -128,7 +128,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=vel * 100, s=scatter_size,
-                    cmap=colormaps["jet_r"],
+                    cmap=cmc.roma,
                     vmin=-v_range, vmax=v_range)
     plt.colorbar(sc, label="[cm / year]", pad=0.03, shrink=0.5)
     plt.title("Mean Velocity")
@@ -143,7 +143,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=coherence, vmin=0, vmax=1, s=scatter_size,
-                    cmap=colormaps["autumn"])
+                    cmap=cmc.lajolla)
     plt.colorbar(sc, label="[-]", pad=0.03, shrink=0.5)
     plt.title("Temporal coherence")
     plt.ylabel('Azimuth')
@@ -161,7 +161,7 @@ def plotMap(*, obj_name: str, save_path: str, interactive: bool = False, input_p
 
     ax = bmap_obj.plot(logger=logger)
     sc = ax.scatter(point_obj.coord_xy[:, 1], point_obj.coord_xy[:, 0], c=stc * 100, s=scatter_size,
-                    cmap=colormaps["autumn_r"])
+                    cmap=cmc.lajolla_r)
     plt.colorbar(sc, label="[cm]", pad=0.03, shrink=0.5)
     plt.title("Spatiotemporal consistency")
     plt.ylabel('Azimuth')

--- a/sarvey/triangulation.py
+++ b/sarvey/triangulation.py
@@ -137,7 +137,7 @@ class PointNetworkTriangulation:
             idx = tree.query(self.coord_xy[p1, :], k)[1]
             self.adj_mat[p1, idx] = True
             count += 1
-            prog_bar.update(value=count + 1, every=np.int16(num_points / 250),
+            prog_bar.update(value=count + 1, every=np.int16(num_points / (num_points / 5)),
                             suffix='{}/{} points triangulated'.format(count + 1, num_points + 1))
         prog_bar.close()
         m, s = divmod(time.time() - start_time, 60)

--- a/sarvey/unwrapping.py
+++ b/sarvey/unwrapping.py
@@ -41,6 +41,7 @@ from scipy.sparse.csgraph import structural_rank
 from scipy.sparse.linalg import lsqr
 from scipy.optimize import minimize
 from logging import Logger
+import cmcrameri as cmc
 
 from mintpy.utils import ptime
 
@@ -1001,7 +1002,7 @@ def parameterBasedNoisyPointRemoval(*, net_par_obj: NetworkParameter, point_id: 
             # vel
             ax = bmap_obj.plot(logger=logger)
             sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=rmse_vel * 1000, s=3.5,
-                            cmap=plt.cm.get_cmap("autumn_r"), vmin=0, vmax=rmse_thrsh * 1000)
+                            cmap=cmc.cm.cmaps["lajolla_r"], vmin=0, vmax=rmse_thrsh * 1000)
             plt.colorbar(sc, pad=0.03, shrink=0.5)
             ax.set_title("{}. iteration\nmean velocity - RMSE per point in [mm / year]".format(it_count))
             fig = ax.get_figure()
@@ -1013,7 +1014,7 @@ def parameterBasedNoisyPointRemoval(*, net_par_obj: NetworkParameter, point_id: 
             # demerr
             ax = bmap_obj.plot(logger=logger)
             sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=rmse_demerr, s=3.5,
-                            cmap=plt.cm.get_cmap("autumn_r"))
+                            cmap=cmc.cm.cmaps["lajolla_r"])
             plt.colorbar(sc, pad=0.03, shrink=0.5)
             ax.set_title("{}. iteration\nDEM correction - RMSE per point in [m]".format(it_count))
             fig = ax.get_figure()

--- a/sarvey/unwrapping.py
+++ b/sarvey/unwrapping.py
@@ -1002,7 +1002,7 @@ def parameterBasedNoisyPointRemoval(*, net_par_obj: NetworkParameter, point_id: 
             # vel
             ax = bmap_obj.plot(logger=logger)
             sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=rmse_vel * 1000, s=3.5,
-                            cmap=cmc.cm.cmaps["lajolla_r"], vmin=0, vmax=rmse_thrsh * 1000)
+                            cmap=cmc.cm.cmaps["lajolla"], vmin=0, vmax=rmse_thrsh * 1000)
             plt.colorbar(sc, pad=0.03, shrink=0.5)
             ax.set_title("{}. iteration\nmean velocity - RMSE per point in [mm / year]".format(it_count))
             fig = ax.get_figure()
@@ -1014,7 +1014,7 @@ def parameterBasedNoisyPointRemoval(*, net_par_obj: NetworkParameter, point_id: 
             # demerr
             ax = bmap_obj.plot(logger=logger)
             sc = ax.scatter(coord_xy[:, 1], coord_xy[:, 0], c=rmse_demerr, s=3.5,
-                            cmap=cmc.cm.cmaps["lajolla_r"])
+                            cmap=cmc.cm.cmaps["lajolla"])
             plt.colorbar(sc, pad=0.03, shrink=0.5)
             ax.set_title("{}. iteration\nDEM correction - RMSE per point in [m]".format(it_count))
             fig = ax.get_figure()

--- a/sarvey/version.py
+++ b/sarvey/version.py
@@ -29,6 +29,6 @@
 
 """Version module for SARvey."""
 
-__version__ = '1.0.0'
-__versiondate__ = '2024-08-12_01'
+__version__ = '1.1.0'
+__versiondate__ = '2024-11-06_01'
 __versionalias__ = 'Strawberry Pie'

--- a/sarvey/viewer.py
+++ b/sarvey/viewer.py
@@ -50,7 +50,8 @@ from sarvey.objects import AmplitudeImage, Points, BaseStack
 import sarvey.utils as ut
 
 
-def plotIfgs(*, phase: np.ndarray, coord: np.ndarray, spatial_ref_idx: int = None, ttl: str = None, cmap: str = "cmy"):
+def plotIfgs(*, phase: np.ndarray, coord: np.ndarray, spatial_ref_idx: int = None, ttl: str = None,
+             cmap: str = "romaO"):
     """Plot one interferogram per subplot.
 
     Parameters
@@ -64,13 +65,8 @@ def plotIfgs(*, phase: np.ndarray, coord: np.ndarray, spatial_ref_idx: int = Non
     ttl: str
         title for the figure (default: None)
     cmap: str
-        colormap, use "cmy" for wrapped phase data (default) or "?" for unwrapped or residual phase
+        colormap name (default: "romaO")
     """
-    if cmap == "cmy":
-        cmap = ColormapExt('cmy').colormap
-    else:
-        cmap = plt.get_cmap(cmap)
-
     num_ifgs = phase.shape[1]
     min_val = np.min(phase)
     max_val = np.max(phase)
@@ -80,7 +76,7 @@ def plotIfgs(*, phase: np.ndarray, coord: np.ndarray, spatial_ref_idx: int = Non
     for i, ax in enumerate(axs.flat):
         if i < num_ifgs:
             sc = ax.scatter(coord[:, 1], coord[:, 0], c=phase[:, i],
-                            vmin=min_val, vmax=max_val, s=1, cmap=cmap)
+                            vmin=min_val, vmax=max_val, s=1, cmap=cmc.cm.cmaps[cmap])
             ax.axes.set_xticks([])
             ax.axes.set_yticks([])
             if spatial_ref_idx is not None:
@@ -312,7 +308,7 @@ class TimeSeriesViewer:
 
         # add radiobutton to select parameter
         self.ax_radio_par = self.fig1.add_axes((0.225, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
-        self.rb_par = widgets.RadioButtons(self.ax_radio_par, labels=['Velocity', 'DEM error', 'None'], active=0)
+        self.rb_par = widgets.RadioButtons(self.ax_radio_par, labels=['Velocity', 'DEM correction', 'None'], active=0)
         self.rb_par.on_clicked(self.plotMap)
 
         # add radiobutton to select background image
@@ -353,7 +349,7 @@ class TimeSeriesViewer:
         self.ax_cbox_par = self.fig2.add_axes((0.525, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.cbox_par = widgets.CheckButtons(
             self.ax_cbox_par,
-            ["Velocity", "DEM error"],
+            ["Velocity", "DEM correction"],
             actives=[True, False]
         )
         self.rb_fit.on_clicked(self.plotPointTimeseries)
@@ -425,17 +421,19 @@ class TimeSeriesViewer:
             v_range = np.max(np.abs(self.vel * self.scale))
             par = self.vel * self.scale
             cb_ttl = f"[{self.vel_scale}/\nyear]"
-        elif self.rb_par.value_selected == "DEM error":  # show demerr
+            cmap = cmc.cm.cmaps["roma"]
+        elif self.rb_par.value_selected == "DEM correction":  # show demerr
             v_range = np.max(np.abs(self.demerr))
             par = self.demerr
             cb_ttl = "[m]"
+            cmap = cmc.cm.cmaps["vanimo"]
 
         if self.rb_par.value_selected != "None":
             self.sc = self.ax_img.scatter(self.point_obj.coord_xy[:, 1],
                                           self.point_obj.coord_xy[:, 0],
                                           c=par,
                                           s=5,
-                                          cmap=cmc.cm.cmaps["roma"],
+                                          cmap=cmap,
                                           vmin=-v_range,
                                           vmax=v_range)
 

--- a/sarvey/viewer.py
+++ b/sarvey/viewer.py
@@ -398,7 +398,7 @@ class TimeSeriesViewer:
                                              valfmt="%.1f")
 
             self.ax_img.imshow(self.temp_coh_img,
-                               cmap=plt.get_cmap("gray"),
+                               cmap=cm.grayC,
                                vmin=np.round(self.sl_coh.val, decimals=1),
                                vmax=1)
             meta = {"ORBIT_DIRECTION": self.bmap_obj.orbit_direction}
@@ -433,7 +433,7 @@ class TimeSeriesViewer:
                                           self.point_obj.coord_xy[:, 0],
                                           c=par,
                                           s=5,
-                                          cmap=colormaps["jet_r"],
+                                          cmap=cm.roma,
                                           vmin=-v_range,
                                           vmax=v_range)
 
@@ -441,7 +441,7 @@ class TimeSeriesViewer:
         self.cb = self.fig1.colorbar(self.sc, cax=self.ax_cb, ax=self.ax_img, pad=0.03, shrink=0.8, aspect=10,
                                      orientation='vertical')
 
-        # add back location of selected sarvey point and current reference
+        # add back location of selected time series point and current reference
         if self.ts_refpoint_idx is not None:  # initial value is None
             y, x = self.point_obj.coord_xy[self.ts_refpoint_idx, :]
             self.ts_refpoint_marker = self.ax_img.scatter(x, y, marker='^', facecolors='none', edgecolors='k')

--- a/sarvey/viewer.py
+++ b/sarvey/viewer.py
@@ -34,14 +34,15 @@ from logging import Logger
 import matplotlib.cm as cm
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
-from matplotlib import colormaps, widgets
+from matplotlib import widgets
 from matplotlib.backend_bases import MouseButton
 from matplotlib.colors import Normalize
 import numpy as np
 from scipy.spatial import KDTree
 import datetime
+import cmcrameri as cmc
 
-from mintpy.objects.colors import ColormapExt
+from mintpy.objects.colors import ColormapExt  # for DEM_print colormap
 from mintpy.utils import readfile
 from mintpy.utils.plot import auto_flip_direction
 
@@ -94,7 +95,7 @@ def plotIfgs(*, phase: np.ndarray, coord: np.ndarray, spatial_ref_idx: int = Non
 
 
 def plotScatter(*, value: np.ndarray, coord: np.ndarray, bmap_obj: AmplitudeImage = None, ttl: str = None,
-                unit: str = None, s: float = 5.0, cmap: colormaps = colormaps["jet_r"], symmetric: bool = False,
+                unit: str = None, s: float = 5.0, cmap: str = "batlow", symmetric: bool = False,
                 logger: Logger, **kwargs: Any):
     """Plot a scatter map for given value.
 
@@ -114,7 +115,7 @@ def plotScatter(*, value: np.ndarray, coord: np.ndarray, bmap_obj: AmplitudeImag
     s: float
         size of the scatter points (default: 5.0)
     cmap: str
-        colormap (default: "jet_r")
+        colormap (default: "batlow")
     symmetric: bool
         plot symmetric colormap extend, i.e. abs(vmin) == abs(vmax) (default: False)
     logger: Logger
@@ -140,10 +141,11 @@ def plotScatter(*, value: np.ndarray, coord: np.ndarray, bmap_obj: AmplitudeImag
 
     if symmetric:
         v_range = np.max(np.abs(value.ravel()))
-        sc = ax.scatter(coord[:, 1], coord[:, 0], c=value, s=s, cmap=plt.get_cmap(cmap),
+        sc = ax.scatter(coord[:, 1], coord[:, 0], c=value, s=s, cmap=cmc.cm.cmaps[cmap],
                         vmin=-v_range, vmax=v_range)
     else:
-        sc = ax.scatter(coord[:, 1], coord[:, 0], c=value, s=s, cmap=plt.get_cmap(cmap), **kwargs)
+        sc = ax.scatter(coord[:, 1], coord[:, 0], c=value, s=s, cmap=cmc.cm.cmaps[cmap], **kwargs)
+
     cb = plt.colorbar(sc, ax=ax, pad=0.03, shrink=0.5)
     cb.ax.set_title(unit)
     ax.set_title(ttl)
@@ -152,7 +154,7 @@ def plotScatter(*, value: np.ndarray, coord: np.ndarray, bmap_obj: AmplitudeImag
 
 
 def plotColoredPointNetwork(*, x: np.ndarray, y: np.ndarray, arcs: np.ndarray, val: np.ndarray, ax: plt.Axes = None,
-                            linewidth: float = 2, cmap_name: str = "seismic", clim: tuple = None):
+                            linewidth: float = 2, cmap: str = "vik", clim: tuple = None):
     """Plot a network of points with colored arcs.
 
     Parameters
@@ -169,8 +171,8 @@ def plotColoredPointNetwork(*, x: np.ndarray, y: np.ndarray, arcs: np.ndarray, v
         axis for plotting (default: None)
     linewidth: float
         line width of the arcs (default: 2)
-    cmap_name: str
-        name of the colormap (default: "seismic")
+    cmap: str
+        name of the colormap (default: "vik")
     clim: tuple
         color limits for the colormap (default: None)
 
@@ -182,7 +184,7 @@ def plotColoredPointNetwork(*, x: np.ndarray, y: np.ndarray, arcs: np.ndarray, v
         current colorbar
     """
     if ax is None:
-        fig = plt.figure(figsize=[15, 5])
+        fig = plt.figure(figsize=(15, 5))
         ax = fig.add_subplot()
     else:
         fig = ax.get_figure()
@@ -193,7 +195,7 @@ def plotColoredPointNetwork(*, x: np.ndarray, y: np.ndarray, arcs: np.ndarray, v
     else:
         norm = Normalize(vmin=clim[0], vmax=clim[1])
 
-    mapper = cm.ScalarMappable(norm=norm, cmap=cm.get_cmap(cmap_name))
+    mapper = cm.ScalarMappable(norm=norm, cmap=cmc.cm.cmaps[cmap])
     mapper_list = [mapper.to_rgba(v) for v in val]
     for m in range(arcs.shape[0]):
         x_val = [x[arcs[m, 0]], x[arcs[m, 1]]]
@@ -293,7 +295,7 @@ class TimeSeriesViewer:
         self.fig1 = plt.figure()
         self.ax_img = self.fig1.subplots(1, 1)
 
-        self.ax_cb = self.fig1.add_axes([0.93, 0.6, 0.015, 0.15])  # (left, bottom, width, height)
+        self.ax_cb = self.fig1.add_axes((0.93, 0.6, 0.015, 0.15))  # (left, bottom, width, height)
         self.cb = self.fig1.colorbar(self.sc,
                                      cax=self.ax_cb,
                                      ax=self.ax_img,
@@ -304,23 +306,23 @@ class TimeSeriesViewer:
 
         # add button to select reference point
         self.set_reference_point = False
-        self.ax_button = self.fig1.add_axes([0.125, 0.9, 0.1, 0.08])  # (left, bottom, width, height)
+        self.ax_button = self.fig1.add_axes((0.125, 0.9, 0.1, 0.08))  # (left, bottom, width, height)
         self.button_mask = widgets.Button(ax=self.ax_button, label='Select\nReference', image=None, color='1')
         self.button_mask.on_clicked(self.updateButtonStatus)
 
         # add radiobutton to select parameter
-        self.ax_radio_par = self.fig1.add_axes([0.225, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_radio_par = self.fig1.add_axes((0.225, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.rb_par = widgets.RadioButtons(self.ax_radio_par, labels=['Velocity', 'DEM error', 'None'], active=0)
         self.rb_par.on_clicked(self.plotMap)
 
         # add radiobutton to select background image
-        self.ax_radio_backgr = self.fig1.add_axes([0.425, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_radio_backgr = self.fig1.add_axes((0.425, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.rb_backgr = widgets.RadioButtons(self.ax_radio_backgr, labels=['Amplitude', 'DEM', 'Coherence', 'None'],
                                               active=0)
         self.rb_backgr.on_clicked(self.plotMap)
 
         # add info box with info about velocity and DEM error of selected pixel
-        self.ax_info_box = self.fig1.add_axes([0.625, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_info_box = self.fig1.add_axes((0.625, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.text_obj_time = self.ax_info_box.text(0.1, 0.1, "")
         self.ax_info_box.set_xticks([], [])
         self.ax_info_box.set_yticks([], [])
@@ -336,11 +338,11 @@ class TimeSeriesViewer:
         self.ax_ts = self.fig2.subplots(1, 1)
 
         # add radiobutton for fitting linear model
-        self.ax_radio_fit = self.fig2.add_axes([0.125, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_radio_fit = self.fig2.add_axes((0.125, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.rb_fit = widgets.RadioButtons(self.ax_radio_fit, labels=['None', 'Linear fit'], active=0)
 
         # add radiobutton for selecting baseline type
-        self.ax_radio_baselines = self.fig2.add_axes([0.325, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_radio_baselines = self.fig2.add_axes((0.325, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.rb_baselines = widgets.RadioButtons(
             self.ax_radio_baselines,
             labels=['Temporal baseline', 'Perpendicular baseline'],
@@ -348,7 +350,7 @@ class TimeSeriesViewer:
         )
 
         # add check box for removing phase due to parameters
-        self.ax_cbox_par = self.fig2.add_axes([0.525, 0.9, 0.2, 0.08])  # (left, bottom, width, height)
+        self.ax_cbox_par = self.fig2.add_axes((0.525, 0.9, 0.2, 0.08))  # (left, bottom, width, height)
         self.cbox_par = widgets.CheckButtons(
             self.ax_cbox_par,
             ["Velocity", "DEM error"],
@@ -389,7 +391,7 @@ class TimeSeriesViewer:
         if self.rb_backgr.value_selected == "Coherence":
             if self.ax_slide_coh is None:
                 # add slider to change value of coherence for background map
-                self.ax_slide_coh = self.fig1.add_axes([0.425, 0.85, 0.2, 0.03])  # (left, bottom, width, height)
+                self.ax_slide_coh = self.fig1.add_axes((0.425, 0.85, 0.2, 0.03))  # (left, bottom, width, height)
                 self.sl_coh = widgets.Slider(self.ax_slide_coh,
                                              label='Coherence',
                                              valmin=0.0,
@@ -398,7 +400,7 @@ class TimeSeriesViewer:
                                              valfmt="%.1f")
 
             self.ax_img.imshow(self.temp_coh_img,
-                               cmap=cm.grayC,
+                               cmap=cmc.cm.cmaps["grayC"],
                                vmin=np.round(self.sl_coh.val, decimals=1),
                                vmax=1)
             meta = {"ORBIT_DIRECTION": self.bmap_obj.orbit_direction}
@@ -406,7 +408,7 @@ class TimeSeriesViewer:
             self.ax_img.set_xlabel("Range")
             self.ax_img.set_ylabel("Azimuth")
         if self.rb_backgr.value_selected == "None":
-            self.ax_img.imshow(np.ones_like(self.height, dtype=np.int8), cmap=plt.cm.get_cmap("gray"), vmin=0, vmax=1)
+            self.ax_img.imshow(np.ones_like(self.height, dtype=np.int8), cmap=cmc.cm.cmaps["grayC"], vmin=0, vmax=1)
             meta = {"ORBIT_DIRECTION": self.bmap_obj.orbit_direction}
             auto_flip_direction(meta, ax=self.ax_img, print_msg=False)
             self.ax_img.set_xlabel("Range")
@@ -433,7 +435,7 @@ class TimeSeriesViewer:
                                           self.point_obj.coord_xy[:, 0],
                                           c=par,
                                           s=5,
-                                          cmap=cm.roma,
+                                          cmap=cmc.cm.cmaps["roma"],
                                           vmin=-v_range,
                                           vmax=v_range)
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with open("sarvey/version.py") as version_file:
 req = [
     "cython", "numpy", "pyproj", "matplotlib", "numba", "scipy",
     "mintpy", "h5py", "overpy", "miaplpy", "gstools", "shapely", "pandas", "geopandas", "pymaxflow",
-    "pillow", "pydantic<=1.10.10", "importlib_resources", "kamui", "json5"
+    "pillow", "pydantic<=1.10.10", "importlib_resources", "kamui", "json5", "cmcrameri"
 ]
 
 req_setup = []

--- a/tests/CI_docker/context/environment_sarvey.yml
+++ b/tests/CI_docker/context/environment_sarvey.yml
@@ -47,3 +47,4 @@ dependencies:
   - pip:
           - kamui[extra]
           - pytest-reporter-html1
+          - cmcrameri


### PR DESCRIPTION
 sarvey_plot:
- [x] -m
     - [x] map_spatiotemporal_consistency.png and map_coherence.png seem to use the same colormaps, but they run in different directions. This is somewhat counter-intuitive.
     - [x] different default colormaps for velocity and DEM correction. (vanimo)
     - [x] revert colormaps for spatiotemporal consistency
     - [x] remove squared sum of residuals
- [x]  -t
    - [x] different default colormaps for velocity and DEM correction (vanimo)
- [x] -i: change to RomaO
- [x] -p: change to RomaO

sarvey MTI:
- [x] different default colormaps for velocity and DEM correction (vanimo)
- [x] revert colormaps for 
     - [x] temporal autocorrelation
     - [x] RMSE of DEM correction and mean velocity
- [x] create new issue for creating config file with default parameters for plotting

General:
- [x]  Update history
- [ ] Create new tag