### PR TITLE
Deploy docs to separate folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,30 @@ jobs:
           conda init bash
           source ~/.bashrc
           source activate ci_temp_env
+          
+          # replace documentation address for tags befro make docs
+          IFS='/' read -r OWNER REPO <<< "${GITHUB_REPOSITORY}"
+          URL_IO="https://${OWNER}.github.io/${REPO}"
+          URL="https://github.com/${OWNER}/${REPO}"
+          echo "Repository Documentation URL: $URL"
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              TAG_NAME=${GITHUB_REF##*/}
+              DOCS_DEFAULT_URL="${URL_IO}/main/docs/"
+              DOCS_URL="${URL_IO}/tags/${TAG_NAME}/docs/"
+              sed -i "s|$DOCS_DEFAULT_URL|$DOCS_URL|g" README.rst
+          fi
+
+          # update new badge URL based on the branch or tag
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              TAG_NAME=${GITHUB_REF##*/}
+              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=$TAG_NAME"
+          else
+              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=main"
+          fi
+          BADGE_DEFAULT_URL="${URL}/actions/workflows/ci.yml/badge.svg"
+          sed -i "s|${BADGE_DEFAULT_URL}|$BADGE_URL|g" README.rst
+
           make docs
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
               mamba env remove --name ci_test_env --yes || echo "Environment ci_test_env does not exist"
+              mamba clean --index-cache --lock --tarballs --packages -y
               pip install conda-merge
               export PATH=$HOME/.local/bin:$PATH # workaround conda-merge not found!
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
               mamba env remove --name ci_test_env --yes || echo "Environment ci_test_env does not exist"
-              mamba clean --index-cache --lock --tarballs --packages -y
+              mamba clean --index-cache --tarballs --packages -y
               pip install conda-merge
               export PATH=$HOME/.local/bin:$PATH # workaround conda-merge not found!
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
     SKIP_DEPLOY: false
-    SKIP_INSTALL: false
+    SKIP_INSTALL: true
     SKIP_TEST: false
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
               mamba env remove --name ci_test_env --yes || echo "Environment ci_test_env does not exist"
               pip install conda-merge
+              export PATH=$HOME/.local/bin:$PATH # workaround conda-merge not found!
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
               # mamba env create --name sarvey_testinstall -f env.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,8 @@ jobs:
           conda init bash
           source ~/.bashrc
           conda env remove --name ci_temp_env --yes || echo "Environment ci_temp_env does not exist"
-          conda create --name ci_temp_env --clone ci_env
+          conda create --prefix /home/runneruser/.conda/envs/ci_temp_env --clone ci_env
           conda activate ci_temp_env
-          # TODO: create the ci_env with the installation of the following packages and remove the following line
-          mamba install conda-forge::sphinx_rtd_theme
         shell: bash
 
   test_sarvey:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           IFS='/' read -r OWNER REPO <<< "${GITHUB_REPOSITORY}"
           URL_IO="https://${OWNER}.github.io/${REPO}"
           URL="https://github.com/${OWNER}/${REPO}"
+          echo "Repository URL: $URL"
           echo "Repository Documentation URL: $URL"
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
@@ -101,6 +102,7 @@ jobs:
           else
               BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=main"
           fi
+          echo "Badge URL: $BADGE_URL"
           BADGE_DEFAULT_URL="${URL}/actions/workflows/ci.yml/badge.svg"
           sed -i "s|${BADGE_DEFAULT_URL}|$BADGE_URL|g" README.rst
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           if: env.SKIP_INSTALL == 'false'
           run: |
               export MAMBA_ROOT_PREFIX="$HOME/.mamba" # to be moved to docker
+              export MAMBA_NO_PRELOAD=1
               source /opt/conda/etc/profile.d/conda.sh
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
   release:
     types: 
       - published
@@ -267,7 +270,7 @@ jobs:
             DOCS_PATH=public/tags/$TAG_NAME
           else
             echo "Deploying to GitHub Pages for main branch"
-            DOCS_PATH=public/dev
+            DOCS_PATH=public/main
           fi
 
           rm -rf  $DOCS_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
               # mamba env create --name sarvey_testinstall -f env.yml
-              mamba env create --name ci_test_env -f env.yml
+              mamba env create --name ci_test_env -f env.yml -v
               # source activate sarvey_testinstall
               conda activate ci_test_env
               pip install git+https://github.com/insarlab/MiaplPy.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
           BADGE_DEFAULT_URL="${URL}/actions/workflows/ci.yml/badge.svg"
           sed -i "s|${BADGE_DEFAULT_URL}|$BADGE_URL|g" README.rst
 
+          echo "README.rst content"
+          cat README.rst
+
           make docs
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,17 +228,14 @@ jobs:
           run: |
               source /opt/conda/etc/profile.d/conda.sh
               conda activate base
-              # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
-              mamba env remove --name ci_test_env --yes || echo "Environment ci_test_env does not exist"
+              mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
               mamba clean --index-cache --tarballs --packages -y
               pip install conda-merge
               export PATH=$HOME/.local/bin:$PATH # workaround conda-merge not found!
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
-              # mamba env create --name sarvey_testinstall -f env.yml
-              mamba env create --name ci_test_env -f env.yml -vvv
-              # source activate sarvey_testinstall
-              conda activate ci_test_env
+              mamba env create --name sarvey_testinstall -f env.yml
+              conda activate sarvey_testinstall
               pip install git+https://github.com/insarlab/MiaplPy.git
               pip install .
               OUTPUT=$(pip check) || { echo "$OUTPUT"; true; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,17 +71,12 @@ jobs:
           make pytest
         shell: bash
 
-  make_docs:
-    runs-on: self-hosted
-    needs: before_script
-    steps:
       - name: create docs
         if: env.SKIP_DEPLOY == 'false'
         run: |
-          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          conda activate ci_temp_env
+          source activate ci_temp_env
           make docs
         shell: bash
 
@@ -122,7 +117,7 @@ jobs:
 
   test_styles:
     runs-on: self-hosted
-    needs: before_script
+    needs: test_sarvey
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -165,7 +160,7 @@ jobs:
 
   test_urls:
     runs-on: self-hosted
-    needs: before_script
+    needs: test_sarvey
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,11 +226,6 @@ jobs:
       -   name: Install dependencies
           if: env.SKIP_INSTALL == 'false'
           run: |
-              export MAMBA_ROOT_PREFIX="$HOME/.mamba" # to be moved to docker
-              export MAMBA_NO_PRELOAD=1
-              export CONDA_OVERRIDE_CUDA=""
-              export CONDA_SUBDIR="linux-64"
-
               source /opt/conda/etc/profile.d/conda.sh
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ permissions:
 
 env:
     SKIP_DEPLOY: false
-    SKIP_INSTALL: true
-    SKIP_TEST: true
+    SKIP_INSTALL: false
+    SKIP_TEST: false
 
 jobs:
   before_script:
@@ -67,7 +67,8 @@ jobs:
           source ~/.bashrc
           conda activate ci_temp_env
           rm -rf tests/testdata
-          wget -nv -c -O testdata.zip https://seafile.projekt.uni-hannover.de/f/4b3be399dffa488e98db/?dl=1
+          # wget -nv -c -O testdata.zip https://seafile.projekt.uni-hannover.de/f/4b3be399dffa488e98db/?dl=1
+          wget -nv -c -O testdata.zip https://seafile.projekt.uni-hannover.de/f/104b499f6f7e4360877d/?dl=1          
           unzip testdata.zip
           mv testdata tests/
           mamba list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   release:
     types: 
       - published
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
   release:
     types: 
       - published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           # update new badge URL based on the branch or tag
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
               TAG_NAME=${GITHUB_REF##*/}
-              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=$TAG_NAME"
+              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?tag=$TAG_NAME"
           else
               BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=main"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
           run: |
               export MAMBA_ROOT_PREFIX="$HOME/.mamba" # to be moved to docker
               export MAMBA_NO_PRELOAD=1
+              export CONDA_OVERRIDE_CUDA=""
+              export CONDA_SUBDIR="linux-64"
+
               source /opt/conda/etc/profile.d/conda.sh
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,15 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
-      - update-runner
       - main
   release:
     types: 
       - published
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
               # mamba env create --name sarvey_testinstall -f env.yml
-              mamba env create --name ci_test_env -f env.yml -vv
+              mamba env create --name ci_test_env -f env.yml -vvv
               # source activate sarvey_testinstall
               conda activate ci_test_env
               pip install git+https://github.com/insarlab/MiaplPy.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
               # mamba env create --name sarvey_testinstall -f env.yml
-              mamba env create --name ci_test_env -f env.yml -v
+              mamba env create --name ci_test_env -f env.yml -vv
               # source activate sarvey_testinstall
               conda activate ci_test_env
               pip install git+https://github.com/insarlab/MiaplPy.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,15 +90,15 @@ jobs:
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
               TAG_NAME=${GITHUB_REF##*/}
-              DOCS_DEFAULT_URL="${URL_IO}/main/docs/"
-              DOCS_URL="${URL_IO}/tags/${TAG_NAME}/docs/"
-              sed -i "s|$DOCS_DEFAULT_URL|$DOCS_URL|g" README.rst
+              DEFAULT_URL="${URL_IO}/main"
+              NEW_URL="${URL_IO}/tags/${TAG_NAME}"
+              sed -i "s|$DEFAULT_URL|$NEW_URL|g" README.rst
           fi
 
           # update new badge URL based on the branch or tag
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
               TAG_NAME=${GITHUB_REF##*/}
-              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?tag=$TAG_NAME"
+              BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=$TAG_NAME"
           else
               BADGE_URL="${URL}/actions/workflows/ci.yml/badge.svg?branch=main"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
     runs-on: self-hosted
 
     needs: 
-      - make_docs
+      - test_sarvey
       - test_urls
       - test_styles
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,19 @@ on:
   pull_request:
   push:
     branches:
+      - update-runner
       - main
+  release:
+    types: 
+      - published
 
 permissions:
   contents: write
 
 env:
     SKIP_DEPLOY: false
-    SKIP_INSTALL: false
-    SKIP_TEST: false
+    SKIP_INSTALL: true
+    SKIP_TEST: true
 
 jobs:
   before_script:
@@ -33,9 +37,14 @@ jobs:
 
       - name: Install dependencies
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          source activate ci_env
+          conda env remove --name ci_temp_env --yes || echo "Environment ci_temp_env does not exist"
+          conda create --name ci_temp_env --clone ci_env
+          conda activate ci_temp_env
+          # TODO: create the ci_env with the installation of the following packages and remove the following line
+          mamba install conda-forge::sphinx_rtd_theme
         shell: bash
 
   test_sarvey:
@@ -53,14 +62,10 @@ jobs:
       - name: Run tests
         if: env.SKIP_TEST == 'false'
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          mamba env remove --name ci_temp_env --yes || echo "Environment ci_temp_env does not exist"
-
-          mamba create -n ci_temp_env --clone ci_env
-          source activate ci_temp_env
-          mamba install json5
-          mamba install cmcrameri
+          conda activate ci_temp_env
           rm -rf tests/testdata
           wget -nv -c -O testdata.zip https://seafile.projekt.uni-hannover.de/f/4b3be399dffa488e98db/?dl=1
           unzip testdata.zip
@@ -69,12 +74,17 @@ jobs:
           make pytest
         shell: bash
 
+  make_docs:
+    runs-on: self-hosted
+    needs: before_script
+    steps:
       - name: create docs
         if: env.SKIP_DEPLOY == 'false'
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          source activate ci_env
+          conda activate ci_temp_env
           make docs
         shell: bash
 
@@ -128,9 +138,10 @@ jobs:
       - name: Install dependencies
         if: env.SKIP_TEST == 'false'
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          source activate ci_env
+          conda activate ci_temp_env
           make lint
         shell: bash
 
@@ -170,9 +181,10 @@ jobs:
       - name: Install dependencies
         if: env.SKIP_TEST == 'false'
         run: |
+          source /opt/conda/etc/profile.d/conda.sh
           conda init bash
           source ~/.bashrc
-          source activate ci_env
+          source activate ci_temp_env
           make urlcheck
         shell: bash
 
@@ -190,13 +202,17 @@ jobs:
       -   name: Install dependencies
           if: env.SKIP_INSTALL == 'false'
           run: |
-              source activate base
-              mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
+              source /opt/conda/etc/profile.d/conda.sh
+              conda activate base
+              # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"
+              mamba env remove --name ci_test_env --yes || echo "Environment ci_test_env does not exist"
               pip install conda-merge
               wget https://raw.githubusercontent.com/insarlab/MiaplPy/main/conda-env.yml
               conda-merge conda-env.yml tests/CI_docker/context/environment_sarvey.yml > env.yml
-              mamba env create --name sarvey_testinstall -f env.yml
-              source activate sarvey_testinstall
+              # mamba env create --name sarvey_testinstall -f env.yml
+              mamba env create --name ci_test_env -f env.yml
+              # source activate sarvey_testinstall
+              conda activate ci_test_env
               pip install git+https://github.com/insarlab/MiaplPy.git
               pip install .
               OUTPUT=$(pip check) || { echo "$OUTPUT"; true; }
@@ -207,8 +223,11 @@ jobs:
   deploy_pages:
     runs-on: self-hosted
 
-    needs: test_sarvey
-    if: github.ref == 'refs/heads/main'
+    needs: 
+      - make_docs
+      - test_urls
+      - test_styles
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -236,21 +255,37 @@ jobs:
           name: test-report
 
       - name: Deploy to GitHub Pages
-        if: env.SKIP_DEPLOY == 'false'
+        # trigger if merged into the main branch || published new tag
+        if: env.SKIP_DEPLOY == 'false' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           rm -rf public
-          mkdir -p public/docs
-          mkdir -p public/images/
-          mkdir -p public/coverage
-          mkdir -p public/test_reports
+          
+          git clone --branch gh-pages https://github.com/${{ github.repository }} public
 
-          cp -r docs/_build/html/* public/docs/
-          cp -r htmlcov/* public/coverage/
-          cp report.html public/test_reports/
-          ls -al public
-          ls -al public/docs
-          ls -al public/coverage
-          ls -al public/test_reports
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME=${GITHUB_REF##*/}
+            echo "Deploying to GitHub Pages for version tag: $TAG_NAME"
+            DOCS_PATH=public/tags/$TAG_NAME
+          else
+            echo "Deploying to GitHub Pages for main branch"
+            DOCS_PATH=public/dev
+          fi
+
+          rm -rf  $DOCS_PATH
+          mkdir -p $DOCS_PATH/docs
+          mkdir -p $DOCS_PATH/images
+          mkdir -p $DOCS_PATH/coverage
+          mkdir -p $DOCS_PATH/test_reports
+          
+          cp -r docs/_build/html/* $DOCS_PATH/docs
+          cp -r htmlcov/* $DOCS_PATH/coverage/
+          cp report.html $DOCS_PATH/test_reports/
+
+          ls -al $DOCS_PATH
+          ls -al $DOCS_PATH/docs
+          ls -al $DOCS_PATH/coverage
+          ls -al $DOCS_PATH/test_reports
+
         shell: bash
 
       - name: Upload to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
       -   name: Install dependencies
           if: env.SKIP_INSTALL == 'false'
           run: |
+              export MAMBA_ROOT_PREFIX="$HOME/.mamba" # to be moved to docker
               source /opt/conda/etc/profile.d/conda.sh
               conda activate base
               # mamba env remove --name sarvey_testinstall --yes || echo "Environment sarvey_testinstall does not exist"

--- a/README.rst
+++ b/README.rst
@@ -186,8 +186,8 @@ This package was created with Cookiecutter_ and the `fernlab/cookiecutter-python
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`fernlab/cookiecutter-python-package`: https://git.gfz-potsdam.de/fernlab/products/cookiecutters/cookiecutter-python-package
-.. _coverage: https://luhipi.github.io/sarvey/coverage/
-.. _pytest: https://luhipi.github.io/sarvey/test_reports/report.html
+.. _coverage: https://luhipi.github.io/sarvey/main/coverage/
+.. _pytest: https://luhipi.github.io/sarvey/main/test_reports/report.html
 .. _processing: https://luhipi.github.io/sarvey/main/docs/processing.html
 .. _`processing steps`: https://luhipi.github.io/sarvey/main/docs/processing.html#processing-steps-for-two-step-unwrapping-workflow
 .. _preparation: https://luhipi.github.io/sarvey/main/docs/preparation.html

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Open-source InSAR time series analysis software developed within the project SAR
 Documentation
 -------------
 The documentation with installation instructions, processing steps, and examples with a demo dataset can be found at:
-https://luhipi.github.io/sarvey/docs/
+https://luhipi.github.io/sarvey/main/docs/
 
 
 
@@ -21,7 +21,7 @@ Status
         :target: https://github.com/luhipi/sarvey/actions
         :alt: Pipelines
 .. image:: https://img.shields.io/static/v1?label=Documentation&message=GitHub%20Pages&color=blue
-        :target: https://luhipi.github.io/sarvey/docs/
+        :target: https://luhipi.github.io/sarvey/main/docs/
         :alt: Documentation
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.12544130.svg
         :target: https://doi.org/10.5281/zenodo.12544130
@@ -188,13 +188,13 @@ This package was created with Cookiecutter_ and the `fernlab/cookiecutter-python
 .. _`fernlab/cookiecutter-python-package`: https://git.gfz-potsdam.de/fernlab/products/cookiecutters/cookiecutter-python-package
 .. _coverage: https://luhipi.github.io/sarvey/coverage/
 .. _pytest: https://luhipi.github.io/sarvey/test_reports/report.html
-.. _processing: https://luhipi.github.io/sarvey/docs/processing.html
-.. _`processing steps`: https://luhipi.github.io/sarvey/docs/processing.html#processing-steps-for-two-step-unwrapping-workflow
-.. _preparation: https://luhipi.github.io/sarvey/docs/preparation.html
-.. _`Two-step unwrapping`: https://luhipi.github.io/sarvey/docs/processing.html#processing-steps-for-two-step-unwrapping-workflow
-.. _`One-step unwrapping`: https://luhipi.github.io/sarvey/docs/processing.html#processing-steps-for-one-step-unwrapping-workflow
-.. _`installation instruction`: https://luhipi.github.io/sarvey/docs/installation.html
-.. _`history`: https://luhipi.github.io/sarvey/docs/history.html
+.. _processing: https://luhipi.github.io/sarvey/main/docs/processing.html
+.. _`processing steps`: https://luhipi.github.io/sarvey/main/docs/processing.html#processing-steps-for-two-step-unwrapping-workflow
+.. _preparation: https://luhipi.github.io/sarvey/main/docs/preparation.html
+.. _`Two-step unwrapping`: https://luhipi.github.io/sarvey/main/docs/processing.html#processing-steps-for-two-step-unwrapping-workflow
+.. _`One-step unwrapping`: https://luhipi.github.io/sarvey/main/docs/processing.html#processing-steps-for-one-step-unwrapping-workflow
+.. _`installation instruction`: https://luhipi.github.io/sarvey/main/docs/installation.html
+.. _`history`: https://luhipi.github.io/sarvey/main/docs/history.html
 .. _MiaplPy: https://github.com/insarlab/MiaplPy
 .. _MintPy: https://github.com/insarlab/MintPy
 .. _ISCE: https://github.com/isce-framework/isce2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,7 @@ intersphinx_mapping = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 # html_theme = 'default'
-html_theme = 'classic'  # The one installed via pip install sphinx_rtd_theme in the .gitlab.yml
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ req_test = ['pytest>=3', 'pytest-cov', 'pytest-reporter-html1', 'urlchecker']
 req_doc = [
     'sphinx>=4.1.1',
     'sphinx-argparse',
-    'sphinx-autodoc-typehints'
+    'sphinx-autodoc-typehints',
+    'sphinx_rtd_theme'
 ]
 
 req_lint = ['flake8', 'pycodestyle', 'pydocstyle']

--- a/tests/CI_docker/context/environment_sarvey.yml
+++ b/tests/CI_docker/context/environment_sarvey.yml
@@ -41,6 +41,7 @@ dependencies:
   - sphinx-argparse
   - sphinx-autodoc-typehints
   - sphinxcontrib-jquery
+  - sphinx_rtd_theme
   # deployment requirements
   - twine
 


### PR DESCRIPTION
This PR
- modifies the runner to deploy various versions of documentation to separate tag folders on gh-pages.
- updates the links to docs in README.rst
- updates the documentation theme.
- uses a smaller set of data for faster tests.

Once merged, I will create the index.html in gh-pages to include different tags and main.
