### PR TITLE
Fix bug in computing grid size

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 Future minor version (release soon)
 -----------------------------------
 
+* Fix numerical problems when computing grid size.
 
 1.2.0 (2025-02-19)
 ------------------

--- a/sarvey/utils.py
+++ b/sarvey/utils.py
@@ -430,8 +430,8 @@ def splitImageIntoBoxesRngAz(*, length: int, width: int, num_box_az: int, num_bo
     num_box: int
         number of boxes
     """
-    y_step = int(np.rint((length / num_box_rng) / 10) * 10)
-    x_step = int(np.rint((width / num_box_az) / 10) * 10)
+    y_step = int(length / num_box_rng)
+    x_step = int(width / num_box_az)
 
     box_list = []
     y0 = 0


### PR DESCRIPTION
Often the computation did not stop when selecting a grid size smaller than 100m in step 1. This seems to have numerical reasons.