### PR TITLE
Show all arcs in spatial network plot in step 1 

### DIFF
--- a/sarvey/processing.py
+++ b/sarvey/processing.py
@@ -311,18 +311,14 @@ class Processing:
 
         # 3) spatial unwrapping of the arc network and removal of outliers (arcs and points)
         bmap_obj = AmplitudeImage(file_path=join(self.path, "background_map.h5"))
-        thrsh_visualisation = 0.7
 
         try:
             ax = bmap_obj.plot(logger=self.logger)
-            arc_mask = net_par_obj.gamma.reshape(-1) <= thrsh_visualisation
             ax, cbar = viewer.plotColoredPointNetwork(x=point_obj.coord_xy[:, 1], y=point_obj.coord_xy[:, 0],
-                                                      arcs=net_par_obj.arcs[arc_mask, :],
-                                                      val=net_par_obj.gamma[arc_mask],
+                                                      arcs=net_par_obj.arcs,
+                                                      val=net_par_obj.gamma,
                                                       ax=ax, linewidth=1, cmap="lajolla", clim=(0, 1))
-            ax.set_title("Coherence from temporal unwrapping\n"
-                         r"(only arcs with $\gamma \leq$ {} "
-                         "shown)\nBefore outlier removal".format(thrsh_visualisation))
+            ax.set_title("Coherence from temporal unwrapping\nBefore outlier removal")
             fig = ax.get_figure()
             plt.tight_layout()
             fig.savefig(join(self.path, "pic", "step_1_arc_coherence.png"), dpi=300)
@@ -340,14 +336,12 @@ class Processing:
 
         try:
             ax = bmap_obj.plot(logger=self.logger)
-            arc_mask = net_par_obj.gamma.reshape(-1) <= thrsh_visualisation
             ax, cbar = viewer.plotColoredPointNetwork(x=coord_xy[:, 1], y=coord_xy[:, 0],
-                                                      arcs=net_par_obj.arcs[arc_mask, :],
-                                                      val=net_par_obj.gamma[arc_mask],
+                                                      arcs=net_par_obj.arcs,
+                                                      val=net_par_obj.gamma,
                                                       ax=ax, linewidth=1, cmap="lajolla", clim=(0, 1))
-            ax.set_title("Coherence from temporal unwrapping\n"
-                         r"(only arcs with $\gamma \leq$ {} "
-                         "shown)\nAfter outlier removal".format(thrsh_visualisation))
+            ax.set_title("Coherence from temporal unwrapping\nAfter outlier removal")
+
             fig = ax.get_figure()
             plt.tight_layout()
             fig.savefig(join(self.path, "pic", "step_1_arc_coherence_reduced.png"), dpi=300)

--- a/sarvey/viewer.py
+++ b/sarvey/viewer.py
@@ -34,7 +34,7 @@ from logging import Logger
 import matplotlib.cm as cm
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
-from matplotlib.collections import PathCollection
+from matplotlib.collections import PathCollection, LineCollection
 from matplotlib import widgets
 from matplotlib.backend_bases import MouseButton
 from matplotlib.colors import Normalize
@@ -198,12 +198,16 @@ def plotColoredPointNetwork(*, x: np.ndarray, y: np.ndarray, arcs: np.ndarray, v
         norm = Normalize(vmin=clim[0], vmax=clim[1])
 
     mapper = cm.ScalarMappable(norm=norm, cmap=cmc.cm.cmaps[cmap])
-    mapper_list = [mapper.to_rgba(v) for v in val]
-    for m in range(arcs.shape[0]):
-        x_val = [x[arcs[m, 0]], x[arcs[m, 1]]]
-        y_val = [y[arcs[m, 0]], y[arcs[m, 1]]]
+    colors = mapper.to_rgba(val)
 
-        ax.plot(x_val, y_val, linewidth=linewidth, c=mapper_list[m])
+    # Prepare line segments for LineCollection
+    line_segments = [
+        [[x[arcs[m, 0]], y[arcs[m, 0]]], [x[arcs[m, 1]], y[arcs[m, 1]]]]
+        for m in range(arcs.shape[0])
+    ]
+    line_collection = LineCollection(line_segments, colors=colors, linewidths=linewidth)
+    ax.add_collection(line_collection)
+
     cbar = fig.colorbar(mapper, ax=ax, pad=0.03, shrink=0.5)
 
     return ax, cbar


### PR DESCRIPTION
Problem:
The spatial network plot in step 1 is not very informative as arcs with high coherence are not shown. The limitation was the computational demand during plotting all arcs separately.

Solution:
The arcs are plotted using LineCollection from matplotlib which is faster. Now, all arcs are shown.

Closes #106.